### PR TITLE
feat : 알람 entity 구현

### DIFF
--- a/src/main/java/com/project/todayWhatToDo/notify/domain/Notify.java
+++ b/src/main/java/com/project/todayWhatToDo/notify/domain/Notify.java
@@ -1,0 +1,31 @@
+package com.project.todayWhatToDo.notify.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+/**
+ * userId 는 USER entity 왜래키로 사용된다.
+ */
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notify {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+    @Column
+    private Long userId;
+    @CreatedDate
+    @Column
+    private LocalDateTime createdAt;
+    @Column
+    private Boolean isChecked;
+    @Column
+    private String content;
+}

--- a/src/main/java/com/project/todayWhatToDo/notify/repository/NotifyRepository.java
+++ b/src/main/java/com/project/todayWhatToDo/notify/repository/NotifyRepository.java
@@ -1,0 +1,7 @@
+package com.project.todayWhatToDo.notify.repository;
+
+import com.project.todayWhatToDo.notify.domain.Notify;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotifyRepository extends JpaRepository<Notify, Long> {
+}

--- a/src/main/java/com/project/todayWhatToDo/notify/service/NotifyService.java
+++ b/src/main/java/com/project/todayWhatToDo/notify/service/NotifyService.java
@@ -1,0 +1,9 @@
+package com.project.todayWhatToDo.notify.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class NotifyService {
+}


### PR DESCRIPTION
알람은 새로운 도메인으로 분리해서 구현했습니다.
erd 설계에 따라서 entity 구현했습니다.
user 도메인과 분리하기 위해서 user 외래키 설정을 하지 않고 구현했습니다.