### PR TITLE
feat : add test library based on openapi3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,56 +1,58 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.1.4'
-	id 'io.spring.dependency-management' version '1.1.3'
-	id 'org.asciidoctor.jvm.convert' version '3.3.2'
+    id 'java'
+    id 'org.springframework.boot' version '3.1.4'
+    id 'io.spring.dependency-management' version '1.1.3'
+    // spring rest docs with open api
+    id 'com.epages.restdocs-api-spec' version '0.18.2'
 }
 
 group = 'com.project'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '21'
+    sourceCompatibility = '21'
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
-}
-
-ext {
-	set('snippetsDir', file("build/generated-snippets"))
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-websocket'
-	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	runtimeOnly 'com.h2database:h2'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    compileOnly 'org.projectlombok:lombok'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    runtimeOnly 'com.h2database:h2'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+//    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+    // spring rest docs with open api
+    testImplementation('com.epages:restdocs-api-spec-mockmvc:0.18.2')
+}
+
+openapi3 {
+    server = 'https://localhost:8080'
+    title = 'Today What To Do?'
+    description = 'API document'
+    version = '0.1.0'
+    format = 'yaml'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
-}
-
-tasks.named('asciidoctor') {
-	inputs.dir snippetsDir
-	dependsOn test
+    useJUnitPlatform()
 }

--- a/docs/docker-compose-swagger-ui.yaml
+++ b/docs/docker-compose-swagger-ui.yaml
@@ -1,0 +1,9 @@
+services:
+  swagger-server:
+    image: swaggerapi/swagger-ui
+    ports:
+      - "8000:8080"
+    volumes:
+      - "../build/api-spec/openapi3.yaml:/usr/share/nginx/html/openapi.yaml"
+    environment:
+      - URL=./openapi.yaml

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,14 +15,8 @@ spring:
         use_sql_comments: true
         globally_quoted_identifiers: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
 
 logging:
   level:
     org.hibernate.type.descriptor.sql: trace
-
-springdoc:
-  api-docs:
-    path: /swagger-ui/api-docs
-  swarger-ui:
-    path: /swagger-ui/docs


### PR DESCRIPTION
## what is change?
1. remove asciidoctor task 
don't use auto generated API document based on spring rest docs with asciidoctor.

2. add openapi3 task
in order to generate OpenAPI3 document, adapt open source library. [openapi3 github repo](https://github.com/ePages-de/restdocs-api-spec)

3. separate swagger ui server
separate swagger ui server from spring boot app.
swagger ui server can run from `project_root/docs/docker-compose-swagger-ui.yaml`